### PR TITLE
feat: set maximum terraform version to 10

### DIFF
--- a/.github/workflows/tf-validate.yaml
+++ b/.github/workflows/tf-validate.yaml
@@ -36,8 +36,8 @@ jobs:
         set -ex  # Exit immediately if a command exits with a non-zero status
 
         # Define start and end versions
-        START_VERSION=${{ inputs.start-version || '3' }}
-        END_VERSION=${{ inputs.end-version || '9' }}
+        START_VERSION=${{ inputs.start-version || '3' }} # minimum version
+        END_VERSION=${{ inputs.end-version || '10' }} # maximum version (up to 1.10.x)
 
         # Check if jq is installed
         if ! command -v jq &> /dev/null; then
@@ -45,7 +45,7 @@ jobs:
           exit 1
         fi
 
-        # Generate Terraform versions from 1.3 to 1.9
+        # Generate Terraform versions from 1.3 to 1.10
         versions=()
         for i in $(seq $START_VERSION $END_VERSION); do
           versions+=("1.$i")


### PR DESCRIPTION
This allows us to validate terraform againt v1.10.x and future proof it, so that is there is a breaking change we can spot it early.
