### PR TITLE
fix: checkov pin to branch

### DIFF
--- a/.github/workflows/tf-security.yaml
+++ b/.github/workflows/tf-security.yaml
@@ -26,7 +26,7 @@ jobs:
           python-version: 3.11
       - name: Test with Checkov
         id: checkov
-        uses: bridgecrewio/checkov-action@12
+        uses: bridgecrewio/checkov-action@master
         with:
           directory: .
           framework: terraform


### PR DESCRIPTION
This pull request updates the Checkov GitHub Action in the Terraform security workflow to use the latest code from the `master` branch instead of the previously pinned version.

* GitHub Actions: Updated the `bridgecrewio/checkov-action` in `.github/workflows/tf-security.yaml` from version `12` to `master` to ensure the workflow uses the most recent Checkov code.