### PR TITLE
chore: upload checkov result to security

### DIFF
--- a/.github/workflows/tf-security.yaml
+++ b/.github/workflows/tf-security.yaml
@@ -10,6 +10,7 @@ jobs:
     permissions:
       actions: read
       pull-requests: write
+      security-events: write
     needs: []
     steps:
       - name: Checkout code
@@ -29,4 +30,14 @@ jobs:
         uses: bridgecrewio/checkov-action@master
         with:
           directory: .
+          download_external_modules: true
           framework: terraform
+          quiet: true
+          soft_fail: true
+          output_format: cli,sarif
+          output_file_path: console,results.sarif
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        if: success() || failure()
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
This pull request updates the `.github/workflows/tf-security.yaml` workflow to enhance Terraform security scanning and reporting. The main improvements include enabling SARIF output for security results, uploading these results to GitHub, and refining the scan configuration for better integration and usability.

**Security scanning and reporting enhancements:**

* Added `security-events: write` permission to allow uploading security scan results to GitHub Security tab.
* Configured the Checkov scan to download external modules and use both CLI and SARIF output formats, improving scan coverage and reporting.
* Enabled quiet mode and soft fail for Checkov to reduce noise and prevent workflow failures on scan issues.
* Set up SARIF file upload using `github/codeql-action/upload-sarif`, making scan results visible in GitHub's Security tab.