### PR TITLE
chore: update maximum version limits for Terraform and Tofu workflows

### DIFF
--- a/.github/workflows/tf-validate.yaml
+++ b/.github/workflows/tf-validate.yaml
@@ -40,7 +40,7 @@ jobs:
 
         # Define start and end versions
         START_VERSION=${{ inputs.start-version || '3' }} # minimum version
-        END_VERSION=${{ inputs.end-version || '11' }} # maximum version (up to 1.11.x)
+        END_VERSION=${{ inputs.end-version || '13' }} # maximum version (up to 1.13.x)
 
         # Check if jq is installed
         if ! command -v jq &> /dev/null; then
@@ -48,7 +48,7 @@ jobs:
           exit 1
         fi
 
-        # Generate Terraform versions from 1.3 to 1.11
+        # Generate Terraform versions from 1.3 to 1.13
         versions=()
         for i in $(seq $START_VERSION $END_VERSION); do
           versions+=("1.$i")

--- a/.github/workflows/tofu-validate.yaml
+++ b/.github/workflows/tofu-validate.yaml
@@ -43,7 +43,7 @@ jobs:
 
         # Define start and end versions
         START_VERSION=${{ inputs.start-version || '6' }} # minimum version (starting 1.6.x)
-        END_VERSION=${{ inputs.end-version || '8' }} # maximum version (up to 1.8.x)
+        END_VERSION=${{ inputs.end-version || '10' }} # maximum version (up to 1.10.x)
 
         # Check if jq is installed
         if ! command -v jq &> /dev/null; then
@@ -51,7 +51,7 @@ jobs:
           exit 1
         fi
 
-        # Generate Tofu versions from 1.6 to 1.8
+        # Generate Tofu versions from 1.6 to 1.10
         versions=()
         for i in $(seq $START_VERSION $END_VERSION); do
           versions+=("1.$i")


### PR DESCRIPTION
This pull request updates the supported version ranges for Terraform and Tofu validation workflows to include more recent minor versions. This ensures that our CI pipelines test against the latest available releases, improving compatibility and coverage.

**Workflow version range updates:**

* [`.github/workflows/tf-validate.yaml`](diffhunk://#diff-6083502ac6fe0fbb617be2030880b5bb7824cffe474024fe2c4fbae96f771679L43-R51): Increased the maximum tested Terraform version from `1.11.x` to `1.13.x`, updating both the version range comments and the version generation logic.
* [`.github/workflows/tofu-validate.yaml`](diffhunk://#diff-d7772f04cd21d018a660d54b21e6db2039b4d3b0e7c35d6ecc0a07f656354ab3L46-R54): Increased the maximum tested Tofu version from `1.8.x` to `1.10.x`, updating both the version range comments and the version generation logic.