### PR TITLE
chore: replace tfsec with checkov

### DIFF
--- a/.github/workflows/tf-security.yaml
+++ b/.github/workflows/tf-security.yaml
@@ -15,12 +15,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-      - name: tfsec
-        uses: aquasecurity/tfsec-action@v1.0.3
-        with:
-          additional_args: "--force-all-dirs --concise-output --code-theme=dark"
-          version: "latest"
-          github_token: ${{ github.token }}
       - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/tf-security.yaml` workflow configuration. The main update is the removal of the `tfsec` security scanning step from the workflow.

* Removed the `tfsec` security scanning step, which previously used `aquasecurity/tfsec-action@v1.0.3` to scan Terraform code for security issues.